### PR TITLE
Use master branch for tripleo repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/centos:centos8
 
 RUN dnf install -y python3 python3-requests && \
-    curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python3 - -b train current && \
+    curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python3 - -b master current && \
     dnf update -y && \
     dnf install -y python3-ironicclient python3-ironic-inspector-client python3-openstackclient && \
     dnf clean all && \


### PR DESCRIPTION
Since we switched to master for the ironic-image, we should also use master here.