### PR TITLE
Use tested packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/centos:centos8
 
 RUN dnf install -y python3 python3-requests && \
-    curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python3 - -b master current && \
+    curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python3 - -b master current-tripleo && \
     dnf update -y && \
     dnf install -y python3-ironicclient python3-ironic-inspector-client python3-openstackclient && \
     dnf clean all && \


### PR DESCRIPTION
The current-tripleo repo is now available for centos8 and we
should use it.