### PR TITLE
Transition away from openstackclient

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
 FROM docker.io/centos:centos8
 
+# Help people find the actual baremetal command
+COPY scripts/openstack /usr/bin/openstack
+
 RUN dnf install -y python3 python3-requests && \
     curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python3 - -b master current-tripleo && \
-    dnf update -y && \
-    dnf install -y python3-ironicclient python3-ironic-inspector-client python3-openstackclient && \
+    dnf update -y --setopt=install_weak_deps=False && \
+    dnf install -y --setopt=install_weak_deps=False python3-ironicclient python3-ironic-inspector-client && \
     dnf clean all && \
-    rm -rf /var/cache/{yum,dnf}/*
+    rm -rf /var/cache/{yum,dnf}/* && \
+    chmod +x /usr/bin/openstack
 
-ENTRYPOINT ["/usr/bin/openstack"]
+ENTRYPOINT ["/usr/bin/baremetal"]

--- a/scripts/openstack
+++ b/scripts/openstack
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "Please use /usr/bin/baremetal instead"
+exit 1


### PR DESCRIPTION
We have /usr/bin/baremetal since a while, let's stop using
openstackclient. It is broken with http_basic auth anyway.