### PR TITLE
Promote Iury to approvers, remove Stephen and Mael

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,9 +6,11 @@ approvers:
  - dtantsur
  - elfosardo
  - hardys
+ - iurygregory
 
 reviewers:
- - iurygregory
+ - zaneb
+
+emeritus_reviewers:
  - maelk
  - stbenjam
- - zaneb


### PR DESCRIPTION
Iury is the Ironic PTL (project team lead) and has been consistently
reviewing ironic-image changes in his reviewer role.

Stephen and Mael have moved to other roles.
