### PR TITLE
uplift to centos9 and fix tripleo repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM docker.io/centos:centos8
+FROM quay.io/centos/centos:stream9
 
 # Help people find the actual baremetal command
 COPY scripts/openstack /usr/bin/openstack
 
 RUN dnf install -y python3 python3-requests && \
-    curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python3 - -b master current-tripleo && \
+    curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/plugins/module_utils/tripleo_repos/main.py | python3 - -b master current-tripleo && \
     dnf update -y --setopt=install_weak_deps=False && \
     dnf install -y --setopt=install_weak_deps=False python3-ironicclient python3-ironic-inspector-client && \
     dnf clean all && \


### PR DESCRIPTION
Uplift the image os to centos stream 9 and fix tripleo repo so ironic-client can be updated to version >= v4.11.0