### PR TITLE
Move hardys to emeritus_approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,7 +5,6 @@ approvers:
  - derekhiggins
  - dtantsur
  - elfosardo
- - hardys
  - iurygregory
 
 reviewers:
@@ -14,3 +13,7 @@ reviewers:
 emeritus_reviewers:
  - maelk
  - stbenjam
+
+emeritus_approvers:
+ - hardys
+


### PR DESCRIPTION
My area of focus has changed, so I can no longer commit to being an approver