### PR TITLE
use image as debug container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM quay.io/centos/centos:stream9
 # Help people find the actual baremetal command
 COPY scripts/openstack /usr/bin/openstack
 
+COPY scripts/ironic.profile /etc/profile.d/ironic.sh
+
 RUN dnf install -y python3 python3-pip && \
     pip install python-ironicclient python-ironic-inspector-client --no-cache-dir && \
     chmod +x /usr/bin/openstack && \
@@ -10,4 +12,4 @@ RUN dnf install -y python3 python3-pip && \
     dnf clean all && \
     rm -rf /var/cache/{yum,dnf}/*
 
-ENTRYPOINT ["/usr/bin/baremetal"]
+ENTRYPOINT ["bash", "-lc", "/usr/bin/baremetal"]

--- a/README.md
+++ b/README.md
@@ -7,3 +7,36 @@ CLI utilities, which are useful for debugging via Ironic APIs.
 
 When updated, builds are automatically triggered on
 [Quay](https://quay.io/repository/metal3-io/ironic-client).
+
+
+Metal3 Baremetal Operator Debugging
+-----------------------------------
+
+The container image can be used to debug the Ironic component of Metal3.
+
+Once a baremetal-operator-ironic container is running, the
+Metal 3 Ironic Client Container container can be
+started as a debug container using the following command line:
+
+```sh
+kubectl debug -it $(kubectl get -n baremetal-operator-system pods -l name=baremetal-operator-ironic -o name) --image=quay.io/metal3-io/ironic-client --target ironic -n baremetal-operator-system
+```
+
+This opens an interactive baremetal cli witin the debug container.
+
+The default authentication type used is "none".
+You may override it, e.g. when using `http_basic`, by
+passing the `--env` parameter to the `kubectl debug` call:
+
+```
+--env OS_AUTH_TYPE=http_basic,OS_ENDPOINT=http://localhost:1234,OS_USERNAME=foo,OS_PASSWORD=bar
+```
+
+The baremetal command can be used to access the
+Python Ironic Client Standalone CLI e.g. one can use
+
+```sh
+baremetal node list
+```
+
+to list all nodes and their states registered in Ironic.

--- a/scripts/ironic.profile
+++ b/scripts/ironic.profile
@@ -1,0 +1,4 @@
+REQUESTS_CA_BUNDLE=/proc/1/root/certs/ca/ironic-inspector/ca.crt
+OS_AUTH_TYPE=none
+OS_ENDPOINT="$(grep 2>/dev/null -A1 service_catalog /proc/1/root/etc/ironic/ironic.conf|tail -1|cut -d\  -f3)"
+export REQUESTS_CA_BUNDLE OS_AUTH_TYPE OS_ENDPOINT


### PR DESCRIPTION
Currently the image only starts the baremetal command without any environment variables set.

This commit introduces the sourcing of the ironic.conf of a pod to which the container can be attached as debug container. The baremetal cli is then directly usable without further "manual" setting of environment variables.

The implementation requires the start of a login shell for the environment to be sourced on startup.

Extended documentation to reflect the use of the
feature.