### PR TITLE
add markdownlint-cli2 for linting markdown

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,9 @@
+# Reference: https://github.com/DavidAnson/markdownlint-cli2#markdownlint-cli2yaml
+
+config:
+  ul-indent:
+    # Kramdown wanted us to have 3 earlier, tho this CLI recommends 2 or 4
+    indent: 3
+
+# Don't autofix anything, we're linting here
+fix: false

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-Metal3 Ironic Client Container
-==============================
+# Metal3 Ironic Client Container
 
-This repo contains the files needed to build a container image with the Ironic CLI utilities, which are useful for debugging via Ironic APIs.
+This repo contains the files needed to build a container image with the Ironic
+CLI utilities, which are useful for debugging via Ironic APIs.
 
-Description
------------
+## Description
 
-When updated, builds are automatically triggered on https://quay.io/repository/metal3-io/ironic-client
+When updated, builds are automatically triggered on
+[Quay](https://quay.io/repository/metal3-io/ironic-client).

--- a/hack/markdownlint.sh
+++ b/hack/markdownlint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# markdownlint-cli2 has config file(s) named .markdownlint-cli2.yaml in the repo
+
+set -eux
+
+IS_CONTAINER="${IS_CONTAINER:-false}"
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
+
+# all md files, but ignore .github
+if [ "${IS_CONTAINER}" != "false" ]; then
+    markdownlint-cli2 "**/*.md" "#.github"
+else
+    "${CONTAINER_RUNTIME}" run --rm \
+        --env IS_CONTAINER=TRUE \
+        --volume "${PWD}:/workdir:ro,z" \
+        --entrypoint sh \
+        --workdir /workdir \
+        docker.io/pipelinecomponents/markdownlint-cli2:0.9.0@sha256:71370df6c967bae548b0bfd0ae313ddf44bfad87da76f88180eff55c6264098c \
+        /workdir/hack/markdownlint.sh "$@"
+fi

--- a/hack/shellcheck.sh
+++ b/hack/shellcheck.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -eux
+
+IS_CONTAINER="${IS_CONTAINER:-false}"
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
+
+if [ "${IS_CONTAINER}" != "false" ]; then
+    TOP_DIR="${1:-.}"
+    find "${TOP_DIR}" \( -name '*.sh' -o -wholename 'scripts/*' \) -exec shellcheck -s bash {} \+
+else
+    "${CONTAINER_RUNTIME}" run --rm \
+        --env IS_CONTAINER=TRUE \
+        --volume "${PWD}:/workdir:ro,z" \
+        --entrypoint sh \
+        --workdir /workdir \
+        docker.io/koalaman/shellcheck-alpine:v0.9.0@sha256:e19ed93c22423970d56568e171b4512c9244fc75dd9114045016b4a0073ac4b7 \
+        /workdir/hack/shellcheck.sh "$@"
+fi


### PR DESCRIPTION
Add markdownlint linter via markdownline-cli2. This CLI version supports the enable/disable rules in markdown files and allows us to ignore issues locally, not just globally.

- project-infra PR https://github.com/metal3-io/project-infra/pull/619 needs to merge for markdownlint here to pass
