### PR TITLE
install ironic client with pip to fix build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,11 @@ FROM quay.io/centos/centos:stream9
 # Help people find the actual baremetal command
 COPY scripts/openstack /usr/bin/openstack
 
-RUN dnf install -y python3 python3-requests && \
-    curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/plugins/module_utils/tripleo_repos/main.py | python3 - -b master current-tripleo && \
-    dnf update -y --setopt=install_weak_deps=False && \
-    dnf install -y --setopt=install_weak_deps=False python3-ironicclient python3-ironic-inspector-client && \
+RUN dnf install -y python3 python3-pip && \
+    pip install python-ironicclient python-ironic-inspector-client --no-cache-dir && \
+    chmod +x /usr/bin/openstack && \
+    dnf update -y && \
     dnf clean all && \
-    rm -rf /var/cache/{yum,dnf}/* && \
-    chmod +x /usr/bin/openstack
+    rm -rf /var/cache/{yum,dnf}/*
 
 ENTRYPOINT ["/usr/bin/baremetal"]


### PR DESCRIPTION
With the sunset of the tripleo-repos project, the docker build started failing. 
It appears that using pip is now the preferred method for installing the ironic-client for Python instead of using RPM packages.
To fix the docker build, switch the build to use pip for installation.

This fixes: #19 

After the build is fixed we can try to keep it healthy in the future with #20 