### PR TITLE
add OWNERS_ALIASES support

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,19 +1,15 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
- - bfournie
- - derekhiggins
- - dtantsur
- - elfosardo
- - iurygregory
+- ironic-client-maintainers
 
 reviewers:
- - zaneb
+- ironic-client-maintainers
+- ironic-client-reviewers
 
 emeritus_reviewers:
- - maelk
- - stbenjam
+- maelk
+- stbenjam
 
 emeritus_approvers:
- - hardys
-
+- hardys

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,12 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+aliases:
+  ironic-client-maintainers:
+  - bfournie
+  - derekhiggins
+  - dtantsur
+  - elfosardo
+  - iurygregory
+
+  ironic-client-reviewers:
+  - zaneb


### PR DESCRIPTION
OWNERS_ALIASES groups are needed for fair blunderbuss review requests.