### PR TITLE
Add Slack notification for image build workflow failure

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -2,7 +2,7 @@ name: build-images-action
 on:
   push:
     branches:
-      - 'main'
+    - 'main'
 permissions: {}
 jobs:
   build:
@@ -12,15 +12,25 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: build ironic-client image
-        uses: toptal/jenkins-job-trigger-action@137fff703dd260b52b53d3ba1960396415abc568 # 1.0.2
-        with:
-          jenkins_url: "https://jenkins.nordix.org/"
-          jenkins_user: "metal3.bot@gmail.com"
-          jenkins_token: ${{ secrets.JENKINS_TOKEN }}
-          job_name: "metal3_ironic-client_container_image_building"
-          job_params: |
-            {
-              "BUILD_CONTAINER_IMAGE_GIT_REFERENCE": "${{ github.ref }}"
-            }
-          job_timeout: "1000"
+    - name: build ironic-client image
+      uses: toptal/jenkins-job-trigger-action@137fff703dd260b52b53d3ba1960396415abc568 # 1.0.2
+      with:
+        jenkins_url: "https://jenkins.nordix.org/"
+        jenkins_user: "metal3.bot@gmail.com"
+        jenkins_token: ${{ secrets.JENKINS_TOKEN }}
+        job_name: "metal3_ironic-client_container_image_building"
+        job_params: |
+          {
+            "BUILD_CONTAINER_IMAGE_GIT_REFERENCE": "${{ github.ref }}"
+          }
+        job_timeout: "1000"
+    - name: Slack Notification on Failure
+      if: ${{ failure() }}
+      uses: rtCamp/action-slack-notify@4e5fb42d249be6a45a298f3c9543b111b02f7907 # 2.3.0
+      env:
+        SLACK_TITLE: 'GitHub Action Failed in ${{ github.repository }}'
+        SLACK_COLOR: '#FF0000'
+        SLACK_MESSAGE: 'The GitHub Action workflow failed for ironic client image build.'
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        SLACK_CHANNEL: metal3-github-actions-notify
+        SLACK_USERNAME: metal3-github-actions-notify


### PR DESCRIPTION
Adds Slack notification for EST internal teams slack channel for image build workflow failures.
This is so a wider audience can more quickly detect failures and avoid scenarios such as #19 where the build was broken for months before anyone noticed.

Also fixed the indent in the file to be consistent with the other repositories in metal3 org

Sadly, this is currently only EST internal hopefully if this works out well we can find a solution were all interested can partake

Fixes: #20 