### PR TITLE
Fix the installation location and drop ironic-inspector

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM quay.io/centos/centos:stream9
 COPY scripts/openstack /usr/bin/openstack
 
 RUN dnf install -y python3 python3-pip && \
-    pip install python-ironicclient python-ironic-inspector-client --no-cache-dir && \
+    pip install python-ironicclient --prefix /usr --no-cache-dir && \
     chmod +x /usr/bin/openstack && \
     dnf update -y && \
     dnf clean all && \


### PR DESCRIPTION
After the switch to pip, the binary is installed in /usr/local/bin,
while the entrypoint is /usr/bin/baremetal. To ensure better
compatibility, tell pip to use /usr as the prefix.

Drop ironic-inspector client: it's deprecated, and Metal3 does not need
it any more.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
