### PR TITLE
🐛CloudInit: baremetal node fails to deploy using a local config drive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM quay.io/centos/centos:stream9
 # Help people find the actual baremetal command
 COPY scripts/openstack /usr/bin/openstack
 
-RUN dnf install -y python3 python3-pip && \
+RUN dnf install -y python3 python3-pip genisoimage && \
     pip install python-ironicclient --prefix /usr --no-cache-dir && \
     chmod +x /usr/bin/openstack && \
     dnf update -y && \


### PR DESCRIPTION
Trying to deploy using a config drive on the client side requires 'genisoimage' binary to be present.
This patch install the missing package.

Fixes #27