### PR TITLE
add relocation notice before archiving the repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Metal3 Ironic Client Container
 
+**NOTE**: This repository content has been merged with
+[metal3-io/ironic-image](https://github.com/metal3-io/ironic-image/resources/ironic-client/)
+and is now archived. Thank you to all past contributors!
+
 This repo contains the files needed to build a container image with the Ironic
 CLI utilities, which are useful for debugging via Ironic APIs.
 


### PR DESCRIPTION
Add relocation notice to help people find the new location of the client.

Ref: #30 